### PR TITLE
allMarkets support, remove MarketInfo

### DIFF
--- a/example/src/AllMarketUpdates.tsx
+++ b/example/src/AllMarketUpdates.tsx
@@ -1,51 +1,39 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Button, Container, Typography, Box } from '@mui/material';
-import { ClientAddressContext, HanjiClientContext } from './clientContext';
-import { MARKET_ADDRESS } from './constants';
-import { type OrderUpdate } from 'hanji-ts-sdk';
+import { HanjiClientContext } from './clientContext';
+import { MarketUpdate } from 'hanji-ts-sdk';
 
-export const UserOrdersUpdates: React.FC = () => {
+export const AllMarketsUpdates: React.FC = () => {
   const [events, setEvents] = useState<any[]>([]);
   const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
   const hanjiClient = useContext(HanjiClientContext);
-  const address = useContext(ClientAddressContext);
 
-  function onUserOrdersUpdated(_marketId: string, data: OrderUpdate[]) {
-    setEvents(prevEvents => [...prevEvents, ...data]);
+  function onAllMarketsUpdateed(data: MarketUpdate[]) {
+    setEvents(_prevEvents => [...data]);
   }
 
   useEffect(() => {
-    hanjiClient.spot.events.userOrdersUpdated.addListener(onUserOrdersUpdated);
+    hanjiClient.spot.events.allMarketUpdated.addListener(onAllMarketsUpdateed);
 
     return () => {
-      hanjiClient.spot.events.userOrdersUpdated.removeListener(onUserOrdersUpdated);
+      hanjiClient.spot.events.allMarketUpdated.removeListener(onAllMarketsUpdateed);
     };
   }, []);
 
   const handleSubscribe = () => {
-    if (!address) {
-      alert('Please connect your wallet first');
-      return;
-    }
     setIsSubscribed(prev => !prev);
     if (!isSubscribed) {
-      hanjiClient.spot.subscribeToUserOrders({
-        market: MARKET_ADDRESS,
-        user: address,
-      });
+      hanjiClient.spot.subscribeToAllMarkets();
     }
     else {
-      hanjiClient.spot.unsubscribeFromUserOrders({
-        market: MARKET_ADDRESS,
-        user: address,
-      });
+      hanjiClient.spot.unsubscribeFromAllMarkets();
     }
   };
 
   return (
     <Container>
       <Typography variant="h6" component="h3" gutterBottom>
-        User Orders Updates
+        All Markets Updates
       </Typography>
       <Button variant="contained" color="primary" onClick={handleSubscribe}>
         {isSubscribed ? 'Unsubscribe' : 'Subscribe'}
@@ -62,4 +50,4 @@ export const UserOrdersUpdates: React.FC = () => {
   );
 };
 
-export default UserOrdersUpdates;
+export default AllMarketsUpdates;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,6 +8,7 @@ import UserOrdersUpdates from './UserOrdersUpdates';
 import { ClientAddressContext, HanjiClientContext, defaultHanjiClient } from './clientContext';
 import ApproveToken from './ApproveToken';
 import OrderbookUpdates from './OrderbookUpdates';
+import AllMarketsUpdates from './AllMarketUpdates';
 
 function App() {
   const [address, setAddress] = useState<string>('');
@@ -45,6 +46,8 @@ function App() {
             <UserOrdersUpdates />
             <Divider />
             <OrderbookUpdates />
+            <Divider />
+            <AllMarketsUpdates />
           </Box>
         </Box>
       </ClientAddressContext.Provider>

--- a/example/src/OrderbookUpdates.tsx
+++ b/example/src/OrderbookUpdates.tsx
@@ -2,14 +2,14 @@ import React, { useState, useEffect, useContext } from 'react';
 import { Button, Container, Typography, Box } from '@mui/material';
 import { HanjiClientContext } from './clientContext';
 import { MARKET_ADDRESS } from './constants';
-import { Orderbook } from 'hanji-ts-sdk';
+import { OrderbookUpdate } from 'hanji-ts-sdk';
 
 export const OrderbookUpdates: React.FC = () => {
   const [events, setEvents] = useState<any[]>([]);
   const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
   const hanjiClient = useContext(HanjiClientContext);
 
-  function onOrderbookUpdateed(_marketId: string, data: Orderbook) {
+  function onOrderbookUpdateed(_marketId: string, data: OrderbookUpdate) {
     setEvents(prevEvents => [...prevEvents, data]);
   }
 

--- a/example/src/UserOrdersUpdates.tsx
+++ b/example/src/UserOrdersUpdates.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Button, Container, Typography, Box } from '@mui/material';
 import { ClientAddressContext, HanjiClientContext } from './clientContext';
-import { MARKET_ADDRESS } from './constants';
-import { type OrderUpdate } from 'hanji-ts-sdk';
+import { FillUpdate, type OrderUpdate } from 'hanji-ts-sdk';
 
 export const UserOrdersUpdates: React.FC = () => {
   const [events, setEvents] = useState<any[]>([]);
@@ -13,12 +12,16 @@ export const UserOrdersUpdates: React.FC = () => {
   function onUserOrdersUpdated(_marketId: string, data: OrderUpdate[]) {
     setEvents(prevEvents => [...prevEvents, ...data]);
   }
+  function onUserFillsUpdated(_marketId: string, data: FillUpdate[]) {
+    setEvents(prevEvents => [...prevEvents, ...data]);
+  }
 
   useEffect(() => {
     hanjiClient.spot.events.userOrdersUpdated.addListener(onUserOrdersUpdated);
-
+    hanjiClient.spot.events.userFillsUpdated.addListener(onUserFillsUpdated);
     return () => {
       hanjiClient.spot.events.userOrdersUpdated.removeListener(onUserOrdersUpdated);
+      hanjiClient.spot.events.userFillsUpdated.removeListener(onUserFillsUpdated);
     };
   }, []);
 
@@ -30,13 +33,17 @@ export const UserOrdersUpdates: React.FC = () => {
     setIsSubscribed(prev => !prev);
     if (!isSubscribed) {
       hanjiClient.spot.subscribeToUserOrders({
-        market: MARKET_ADDRESS,
+        user: address,
+      });
+      hanjiClient.spot.subscribeToUserFills({
         user: address,
       });
     }
     else {
       hanjiClient.spot.unsubscribeFromUserOrders({
-        market: MARKET_ADDRESS,
+        user: address,
+      });
+      hanjiClient.spot.unsubscribeFromUserFills({
         user: address,
       });
     }
@@ -45,7 +52,7 @@ export const UserOrdersUpdates: React.FC = () => {
   return (
     <Container>
       <Typography variant="h6" component="h3" gutterBottom>
-        User Orders Updates
+        User Orders and Fills Updates
       </Typography>
       <Button variant="contained" color="primary" onClick={handleSubscribe}>
         {isSubscribed ? 'Unsubscribe' : 'Subscribe'}

--- a/integration/testConfig.ts
+++ b/integration/testConfig.ts
@@ -41,6 +41,7 @@ const testMarkets = {
     bestBid: expect.any(BigNumber),
     rawTradingVolume24h: expect.any(BigInt),
     tradingVolume24h: expect.any(BigNumber),
+    totalSupply: expect.any(BigNumber),
     lastTouched: expect.any(BigInt),
   },
   xtzUsd: {
@@ -82,6 +83,7 @@ const testMarkets = {
     bestBid: expect.any(BigNumber),
     rawTradingVolume24h: expect.any(BigInt),
     tradingVolume24h: expect.any(BigNumber),
+    totalSupply: expect.any(BigNumber),
     lastTouched: expect.any(Number),
   },
 } as const satisfies Record<string, Market>;

--- a/integration/tests/spot/hanjiSpotHttpService.test.ts
+++ b/integration/tests/spot/hanjiSpotHttpService.test.ts
@@ -20,23 +20,23 @@ describe('Hanji Spot HTTP Client', () => {
   });
 
   test('get xtzusd market info', async () => {
-    const market = testConfig.testMarkets.xtzUsd.id;
-    const marketInfo = await hanjiClient.spot.getMarketInfo({ market });
-    if (marketInfo) {
-      expect(marketInfo.orderbookAddress).toBe(market);
-      expect(marketInfo.scalingFactors.baseToken).toBe(testConfig.testMarkets.xtzUsd.tokenXScalingFactor);
-      expect(marketInfo.scalingFactors.quoteToken).toBe(testConfig.testMarkets.xtzUsd.tokenYScalingFactor);
-      expect(marketInfo.scalingFactors.price).toBe(testConfig.testMarkets.xtzUsd.priceScalingFactor);
-      expect(marketInfo.lastPrice).toEqual(testConfig.testMarkets.xtzUsd.lastPrice);
-      expect(marketInfo.lowPrice24h).toEqual(testConfig.testMarkets.xtzUsd.lowPrice24h);
-      expect(marketInfo.highPrice24h).toEqual(testConfig.testMarkets.xtzUsd.highPrice24h);
-      expect(marketInfo.bestAsk).toEqual(testConfig.testMarkets.xtzUsd.bestAsk);
-      expect(marketInfo.bestBid).toEqual(testConfig.testMarkets.xtzUsd.bestBid);
-      expect(marketInfo.tradingVolume24h).toEqual(testConfig.testMarkets.xtzUsd.tradingVolume24h);
-      expect(marketInfo.lastTouched).toEqual(testConfig.testMarkets.xtzUsd.lastTouched);
+    const marketId = testConfig.testMarkets.xtzUsd.id;
+    const market = await hanjiClient.spot.getMarket({ market: marketId });
+    if (market) {
+      expect(market.orderbookAddress).toBe(marketId);
+      expect(market.tokenXScalingFactor).toBe(testConfig.testMarkets.xtzUsd.tokenXScalingFactor);
+      expect(market.tokenYScalingFactor).toBe(testConfig.testMarkets.xtzUsd.tokenYScalingFactor);
+      expect(market.priceScalingFactor).toBe(testConfig.testMarkets.xtzUsd.priceScalingFactor);
+      expect(market.lastPrice).toEqual(testConfig.testMarkets.xtzUsd.lastPrice);
+      expect(market.lowPrice24h).toEqual(testConfig.testMarkets.xtzUsd.lowPrice24h);
+      expect(market.highPrice24h).toEqual(testConfig.testMarkets.xtzUsd.highPrice24h);
+      expect(market.bestAsk).toEqual(testConfig.testMarkets.xtzUsd.bestAsk);
+      expect(market.bestBid).toEqual(testConfig.testMarkets.xtzUsd.bestBid);
+      expect(market.tradingVolume24h).toEqual(testConfig.testMarkets.xtzUsd.tradingVolume24h);
+      expect(market.lastTouched).toEqual(testConfig.testMarkets.xtzUsd.lastTouched);
     }
     else {
-      throw new Error('marketInfo is undefined');
+      throw new Error('market is undefined');
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export {
   type GetTradesParams,
   type GetFillsParams,
   type GetTokensParams,
-  type GetMarketInfoParams,
+  type GetMarketParams,
   type GetMarketsParams,
   type GetCandlesParams
 

--- a/src/models/spot.ts
+++ b/src/models/spot.ts
@@ -166,6 +166,11 @@ export interface Market {
   tradingVolume24h: BigNumber | null;
 
   /**
+   * The total supply of the market as a BigNumber, or null if not available.
+   */
+  totalSupply: BigNumber | null;
+
+  /**
    * The timestamp of the last update as a number.
    */
   lastTouched: number;
@@ -527,119 +532,6 @@ export interface Fill {
 }
 
 export type FillUpdate = Fill;
-
-/**
- * Interface representing market information.
- */
-export interface MarketInfo {
-  /**
-   * Unique identifier for the market.
-   *
-   * @type {string}
-   */
-  id: string;
-
-  /**
-   * Name of the market.
-   *
-   * @type {string}
-   */
-  name: string;
-
-  /**
-   * Symbol representing the market.
-   *
-   * @type {string}
-   */
-  symbol: string;
-
-  /**
-   * Base token of the market.
-   *
-   * @type {Token}
-   */
-  baseToken: Token;
-
-  /**
-   * Quote token of the market.
-   *
-   * @type {Token}
-   */
-  quoteToken: Token;
-
-  /**
-   * Address of the market contract, i.e., orderbook.
-   *
-   * @type {string}
-   */
-  orderbookAddress: string;
-
-  /**
-   * Scaling factors for the market.
-   */
-  scalingFactors: {
-    /**
-     * Scaling factor for the base token.
-     *
-     * @type {number}
-     */
-    baseToken: number;
-
-    /**
-     * Scaling factor for the quote token.
-     *
-     * @type {number}
-     */
-    quoteToken: number;
-
-    /**
-     * Scaling factor for the price.
-     *
-     * @type {number}
-     */
-    price: number;
-  };
-
-  /**
-   * The last price of the market as a BigNumber, or null if not available.
-   */
-  lastPrice: BigNumber | null;
-
-  /**
-   * The lowest price in the last 24 hours as a BigNumber, or null if not available.
-   */
-  lowPrice24h: BigNumber | null;
-
-  /**
-   * The highest price in the last 24 hours as a BigNumber, or null if not available.
-   */
-  highPrice24h: BigNumber | null;
-
-  /**
-   * The price one day ago as a BigNumber, or null if not available.
-   */
-  price24h: BigNumber | null;
-
-  /**
-   * The best ask price as a BigNumber, or null if not available.
-   */
-  bestAsk: BigNumber | null;
-
-  /**
-   * The best bid price as a BigNumber, or null if not available.
-   */
-  bestBid: BigNumber | null;
-
-  /**
-   * The trading volume in the last 24 hours as a BigNumber, or null if not available.
-   */
-  tradingVolume24h: BigNumber | null;
-
-  /**
-   * The timestamp of the last update as a number.
-   */
-  lastTouched: number;
-}
 
 /**
  * Represents a candle in the trading system.

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -1,0 +1,1 @@
+export const ALL_MARKETS_ID = 'allMarkets';

--- a/src/services/hanjiSpotService/hanjiSpotService.ts
+++ b/src/services/hanjiSpotService/hanjiSpotService.ts
@@ -2,6 +2,7 @@ import type { CandleDto, FillDto, MarketDto, OrderDto, OrderbookDto, TokenDto, T
 import type { GetCandlesParams, GetFillsParams, GetMarketsParams, GetOrderbookParams, GetOrdersParams, GetTokensParams, GetTradesParams } from './params';
 import { guards } from '../../utils';
 import { RemoteService } from '../remoteService';
+import { ALL_MARKETS_ID } from '../constants';
 
 /**
  * HanjiSpotService provides methods to interact with the Hanji spot market API.
@@ -113,7 +114,7 @@ export class HanjiSpotService extends RemoteService {
    */
   async getMarkets(params: GetMarketsParams): Promise<MarketDto[]> {
     const queryParams = new URLSearchParams();
-    if (params.market)
+    if (params.market && params.market !== ALL_MARKETS_ID)
       queryParams.append('market', params.market);
 
     const queryParamsString = decodeURIComponent(queryParams.toString());

--- a/src/services/hanjiSpotWebSocketService/hanjiSpotWebSocketService.ts
+++ b/src/services/hanjiSpotWebSocketService/hanjiSpotWebSocketService.ts
@@ -20,8 +20,8 @@ import {
   type HanjiWebSocketResponseDto, type PublicEventEmitter, type ToEventEmitter
 } from '../../common';
 import { getErrorLogMessage } from '../../logging';
+import { ALL_MARKETS_ID } from '../constants';
 
-const ALL_MARKETS_ID = 'allMarkets';
 const ALL_MARKETS_CHANNEL = 'allMarkets';
 
 interface HanjiSpotWebSocketServiceEvents {

--- a/src/services/hanjiSpotWebSocketService/hanjiSpotWebSocketService.ts
+++ b/src/services/hanjiSpotWebSocketService/hanjiSpotWebSocketService.ts
@@ -21,6 +21,9 @@ import {
 } from '../../common';
 import { getErrorLogMessage } from '../../logging';
 
+const ALL_MARKETS_ID = 'allMarkets';
+const ALL_MARKETS_CHANNEL = 'allMarkets';
+
 interface HanjiSpotWebSocketServiceEvents {
   marketUpdated: PublicEventEmitter<readonly [marketId: string, data: MarketUpdateDto]>;
   allMarketsUpdated: PublicEventEmitter<readonly [data: MarketUpdateDto[]]>;
@@ -100,7 +103,7 @@ export class HanjiSpotWebSocketService implements Disposable {
     this.startHanjiWebSocketClientIfNeeded();
 
     this.hanjiWebSocketClient.subscribe({
-      channel: 'allMarkets',
+      channel: ALL_MARKETS_CHANNEL,
     });
   }
 
@@ -109,7 +112,7 @@ export class HanjiSpotWebSocketService implements Disposable {
    */
   unsubscribeFromAllMarkets() {
     this.hanjiWebSocketClient.unsubscribe({
-      channel: 'allMarkets',
+      channel: ALL_MARKETS_CHANNEL,
     });
   }
 
@@ -173,7 +176,7 @@ export class HanjiSpotWebSocketService implements Disposable {
     this.hanjiWebSocketClient.subscribe({
       channel: 'userOrders',
       user: params.user,
-      market: params.market,
+      market: params.market || ALL_MARKETS_ID,
     });
   }
 
@@ -185,7 +188,7 @@ export class HanjiSpotWebSocketService implements Disposable {
     this.hanjiWebSocketClient.unsubscribe({
       channel: 'userOrders',
       user: params.user,
-      market: params.market,
+      market: params.market || ALL_MARKETS_ID,
     });
   }
 
@@ -199,7 +202,7 @@ export class HanjiSpotWebSocketService implements Disposable {
     this.hanjiWebSocketClient.subscribe({
       channel: 'userFills',
       user: params.user,
-      market: params.market,
+      market: params.market || ALL_MARKETS_ID,
     });
   }
 
@@ -211,7 +214,7 @@ export class HanjiSpotWebSocketService implements Disposable {
     this.hanjiWebSocketClient.unsubscribe({
       channel: 'userFills',
       user: params.user,
-      market: params.market,
+      market: params.market || ALL_MARKETS_ID,
     });
   }
 
@@ -265,9 +268,8 @@ export class HanjiSpotWebSocketService implements Disposable {
     try {
       if (!message.data)
         return;
-
       switch (message.channel) {
-        case 'allMarkets':
+        case ALL_MARKETS_CHANNEL:
           (this.events.allMarketsUpdated as ToEventEmitter<typeof this.events.allMarketsUpdated>).emit(message.data as MarketUpdateDto[]);
           break;
         case 'market':

--- a/src/services/hanjiSpotWebSocketService/params.ts
+++ b/src/services/hanjiSpotWebSocketService/params.ts
@@ -18,13 +18,13 @@ export type UnsubscribeFromTradesParams = SubscribeToTradesParams;
 
 export interface SubscribeToUserOrdersParams {
   user: string;
-  market: string;
+  market?: string;
 }
 export type UnsubscribeFromUserOrdersParams = SubscribeToUserOrdersParams;
 
 export interface SubscribeToUserFillsParams {
   user: string;
-  market: string;
+  market?: string;
 }
 export type UnsubscribeFromUserFillsParams = SubscribeToUserFillsParams;
 

--- a/src/spot/index.ts
+++ b/src/spot/index.ts
@@ -14,7 +14,7 @@ export type {
   GetTradesParams,
   GetFillsParams,
   GetTokensParams,
-  GetMarketInfoParams,
+  GetMarketParams,
   GetMarketsParams,
   GetCandlesParams
 } from './params';

--- a/src/spot/mappers.ts
+++ b/src/spot/mappers.ts
@@ -50,6 +50,7 @@ export const mapMarketDtoToMarket = (dto: MarketDto, priceFactor: number): Marke
     bestBid: dto.bestBid ? tokenUtils.convertTokensRawAmountToAmount(dto.bestBid, priceFactor) : null,
     rawTradingVolume24h: dto.tradingVolume24h ? BigInt(dto.tradingVolume24h) : null,
     tradingVolume24h: dto.tradingVolume24h ? tokenUtils.convertTokensRawAmountToAmount(dto.tradingVolume24h, priceFactor) : null,
+    totalSupply: dto.totalSupply ? BigNumber(dto.totalSupply) : null,
     lastTouched: dto.lastTouched,
   };
 };

--- a/src/spot/params.ts
+++ b/src/spot/params.ts
@@ -358,7 +358,7 @@ export interface GetTokensParams {
   token?: string;
 }
 
-export interface GetMarketInfoParams {
+export interface GetMarketParams {
   /**
    * Id of the requested market
    *

--- a/src/spot/params.ts
+++ b/src/spot/params.ts
@@ -436,13 +436,13 @@ export type UnsubscribeFromTradesParams = SubscribeToTradesParams;
 
 export interface SubscribeToUserOrdersParams {
   user: string;
-  market: string;
+  market?: string;
 }
 export type UnsubscribeFromUserOrdersParams = SubscribeToUserOrdersParams;
 
 export interface SubscribeToUserFillsParams {
   user: string;
-  market: string;
+  market?: string;
 }
 export type UnsubscribeFromUserFillsParams = SubscribeToUserFillsParams;
 


### PR DESCRIPTION
1. [Added allMarket subscription to Hanji spot](https://github.com/longgammalabs/hanji-ts-sdk/commit/cd84d2c04716ccd1e5cd66bd256650b5155cbc2e)
2. [Added support to subscribe to user fills and ordes for all markets](https://github.com/longgammalabs/hanji-ts-sdk/commit/c93a20acb2ee7b7e4bb59f082433ce6547a9ae57)
3. [MarketInfo is removed, use Market instead](https://github.com/longgammalabs/hanji-ts-sdk/commit/8219719abeb68a7c176782c3664afb5e4f11ed09)
