### PR TITLE
Place market orders by input quote token

### DIFF
--- a/integration/tests/spot/depositAndWithdraw.test.ts
+++ b/integration/tests/spot/depositAndWithdraw.test.ts
@@ -1,0 +1,69 @@
+import BigNumber from 'bignumber.js';
+import { ethers, type ContractTransactionResponse, type Provider, type Wallet } from 'ethers';
+
+import { HanjiClient } from '../../../src';
+import { getTestConfig, type TestConfig } from '../../testConfig';
+import { transactionRegex } from '../../testHelpers';
+import { erc20Abi } from '../../../src/abi';
+
+describe('Hanji Spot Client Contract API', () => {
+  let testConfig: TestConfig;
+  let provider: Provider;
+  let wallet: Wallet;
+  let hanjiClient: HanjiClient;
+
+  beforeAll(async () => {
+    testConfig = getTestConfig();
+    provider = new ethers.JsonRpcProvider(testConfig.rpcUrl);
+    wallet = new ethers.Wallet(testConfig.accountPrivateKey, provider);
+    // check if user has 1 unit of each token for interacting
+    let contract = new ethers.Contract(testConfig.testMarkets.xtzUsd.baseToken.contractAddress, erc20Abi, provider);
+    let balance = await contract.balanceOf!(wallet.address);
+    if (balance < 1n * (10n ** BigInt(testConfig.testMarkets.xtzUsd.baseToken.decimals))) {
+      throw new Error('User does not have 1 unit of base token');
+    }
+    contract = new ethers.Contract(testConfig.testMarkets.xtzUsd.quoteToken.contractAddress, erc20Abi, provider);
+    balance = await contract.balanceOf!(wallet.address);
+    if (balance < 1n * (10n ** BigInt(testConfig.testMarkets.xtzUsd.quoteToken.decimals))) {
+      throw new Error('User does not have 1 unit of base token');
+    }
+    hanjiClient = new HanjiClient({
+      apiBaseUrl: testConfig.hanjiApiBaseUrl,
+      webSocketApiBaseUrl: testConfig.hanjiWebsocketBaseUrl,
+      signer: wallet,
+      webSocketConnectImmediately: false,
+    });
+  }, 15_000);
+
+  test.each([
+    // isBaseToken, approveTokensAmount, baseTokenAmount, quoteTokenAmount
+    [true, new BigNumber(1), new BigNumber(1), new BigNumber(0)],
+    [false, new BigNumber(1), new BigNumber(0), new BigNumber(1)],
+    [true, 1_000n * (10n ** 15n), 1_000n, 0n],
+    [false, 1_000n * (10n ** 11n), 0n, 1_000n],
+  ])('Deposit and Withdraw [isBase: %p, base: %i, quote: %i]', async (isBaseToken, approveTokensAmount, baseTokenAmount, quoteTokenAmount) => {
+    const market = testConfig.testMarkets.xtzUsd.id;
+    let tx: ContractTransactionResponse;
+
+    tx = await hanjiClient.spot.approveTokens({
+      market,
+      amount: approveTokensAmount,
+      isBaseToken,
+    });
+    expect(tx.hash).toMatch(transactionRegex);
+
+    tx = await hanjiClient.spot.depositTokens({
+      market,
+      baseTokenAmount,
+      quoteTokenAmount,
+    });
+    expect(tx.hash).toMatch(transactionRegex);
+
+    tx = await hanjiClient.spot.withdrawTokens({
+      market,
+      baseTokenAmount,
+      quoteTokenAmount,
+    });
+    expect(tx.hash).toMatch(transactionRegex);
+  }, 30_000);
+});

--- a/integration/tests/spot/placeMarketOrder.test.ts
+++ b/integration/tests/spot/placeMarketOrder.test.ts
@@ -1,0 +1,68 @@
+import BigNumber from 'bignumber.js';
+import { ethers, type ContractTransactionResponse, type Provider, type Wallet } from 'ethers';
+
+import { HanjiClient } from '../../../src';
+import { getTestConfig, type TestConfig } from '../../testConfig';
+import { transactionRegex } from '../../testHelpers';
+import { erc20Abi } from '../../../src/abi';
+
+describe('Hanji Spot Client Contract API', () => {
+  let testConfig: TestConfig;
+  let provider: Provider;
+  let wallet: Wallet;
+  let hanjiClient: HanjiClient;
+
+  beforeAll(async () => {
+    testConfig = getTestConfig();
+    provider = new ethers.JsonRpcProvider(testConfig.rpcUrl);
+    wallet = new ethers.Wallet(testConfig.accountPrivateKey, provider);
+    // check if user has 1 unit of each token for interacting
+    let contract = new ethers.Contract(testConfig.testMarkets.xtzUsd.baseToken.contractAddress, erc20Abi, provider);
+    let balance = await contract.balanceOf!(wallet.address);
+    if (balance < 1n * (10n ** BigInt(testConfig.testMarkets.xtzUsd.baseToken.decimals))) {
+      throw new Error('User does not have 1 unit of base token');
+    }
+    contract = new ethers.Contract(testConfig.testMarkets.xtzUsd.quoteToken.contractAddress, erc20Abi, provider);
+    balance = await contract.balanceOf!(wallet.address);
+    if (balance < 1n * (10n ** BigInt(testConfig.testMarkets.xtzUsd.quoteToken.decimals))) {
+      throw new Error('User does not have 1 unit of base token');
+    }
+    hanjiClient = new HanjiClient({
+      apiBaseUrl: testConfig.hanjiApiBaseUrl,
+      webSocketApiBaseUrl: testConfig.hanjiWebsocketBaseUrl,
+      signer: wallet,
+      webSocketConnectImmediately: false,
+    });
+  }, 15_000);
+
+  test('Send market buy and sell orders', async () => {
+    const market = testConfig.testMarkets.xtzUsd.id;
+    let tx: ContractTransactionResponse;
+
+    const info = await hanjiClient.spot.getMarket({ market });
+    expect(info).toBeDefined();
+    expect(info?.bestBid).not.toBeNull();
+    tx = await hanjiClient.spot.placeMarketOrderWithTargetValue({
+      market,
+      side: 'ask',
+      price: info!.bestBid as BigNumber,
+      maxCommission: BigNumber(1),
+      size: BigNumber(0.1),
+      quantityToSend: BigNumber(1),
+      transferExecutedTokens: true,
+    });
+    expect(tx.hash).toMatch(transactionRegex);
+
+    expect(info?.bestAsk).not.toBeNull();
+    tx = await hanjiClient.spot.placeMarketOrderWithTargetValueWithPermit({
+      market,
+      side: 'bid',
+      price: info!.bestAsk as BigNumber,
+      maxCommission: BigNumber(1),
+      size: BigNumber(0.1),
+      permit: BigNumber(0.1),
+      transferExecutedTokens: true,
+    });
+    expect(tx.hash).toMatch(transactionRegex);
+  }, 30_000);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ export {
   type DepositSpotParams,
   type WithdrawSpotParams,
   type PlaceOrderSpotParams,
+  type PlaceOrderWithPermitSpotParams,
+  type PlaceMarketOrderWithTargetValueParams,
+  type PlaceMarketOrderWithTargetValueWithPermitParams,
   type ChangeOrderSpotParams,
   type ClaimOrderSpotParams,
 

--- a/src/spot/hanjiSpot.ts
+++ b/src/spot/hanjiSpot.ts
@@ -37,7 +37,9 @@ import type {
   CalculateLimitDetailsParams,
   CalculateMarketDetailsParams,
   GetUserBalancesParams,
-  PlaceOrderWithPermitSpotParams
+  PlaceOrderWithPermitSpotParams,
+  PlaceMarketOrderWithTargetValueParams,
+  PlaceMarketOrderWithTargetValueWithPermitParams
 } from './params';
 import { EventEmitter, type PublicEventEmitter, type ToEventEmitter } from '../common';
 import { getErrorLogMessage } from '../logging';
@@ -297,10 +299,40 @@ export class HanjiSpot implements Disposable {
     return marketContract.placeOrder(params);
   }
 
+  /**
+   * Places a new order with a permit in the corresponding market contract.
+   *
+   * @param {PlaceOrderWithPermitSpotParams} params - The parameters for placing a new order with a permit.
+   * @return {Promise<ContractTransactionResponse>} A Promise that resolves to the transaction response.
+   */
   async placeOrderWithPermit(params: PlaceOrderWithPermitSpotParams): Promise<ContractTransactionResponse> {
     const marketContract = await this.getSpotMarketContract(params);
 
     return marketContract.placeOrderWithPermit(params);
+  }
+
+  /**
+   * Places a market order with a quote token value in the corresponding market contract.
+   *
+   * @param {PlaceMarketOrderWithTargetValueParams} params - The parameters for placing a market order with a target value.
+   * @return {Promise<ContractTransactionResponse>} A Promise that resolves to the transaction response.
+   */
+  async placeMarketOrderWithTargetValue(params: PlaceMarketOrderWithTargetValueParams): Promise<ContractTransactionResponse> {
+    const marketContract = await this.getSpotMarketContract(params);
+
+    return marketContract.placeMarketOrderWithTargetValue(params);
+  }
+
+  /**
+   * Places a market order with a quote token value and a permit in the corresponding market contract.
+   *
+   * @param {PlaceMarketOrderWithTargetValueWithPermitParams} params - The parameters for placing a market order with a target value and a permit.
+   * @return {Promise<ContractTransactionResponse>} A Promise that resolves to the transaction response.
+   */
+  async placeMarketOrderWithTargetValueWithPermit(params: PlaceMarketOrderWithTargetValueWithPermitParams): Promise<ContractTransactionResponse> {
+    const marketContract = await this.getSpotMarketContract(params);
+
+    return marketContract.placeMarketOrderWithTargetValueWithPermit(params);
   }
 
   /**

--- a/src/spot/index.ts
+++ b/src/spot/index.ts
@@ -6,6 +6,9 @@ export type {
   DepositSpotParams,
   WithdrawSpotParams,
   PlaceOrderSpotParams,
+  PlaceOrderWithPermitSpotParams,
+  PlaceMarketOrderWithTargetValueParams,
+  PlaceMarketOrderWithTargetValueWithPermitParams,
   ChangeOrderSpotParams,
   ClaimOrderSpotParams,
 

--- a/src/spot/params.ts
+++ b/src/spot/params.ts
@@ -137,7 +137,7 @@ export interface PlaceOrderSpotParams {
   maxCommission: BigNumber | bigint;
 
   /**
-   * The quantity of tokens to send for the order.
+   * The quantity of native tokens to send for the order.
    * This is the amount of tokens that will be transferred for the order.
    *
    * @type {BigNumber | bigint}
@@ -228,6 +228,10 @@ export interface PlaceOrderWithPermitSpotParams {
    */
   transferExecutedTokens?: boolean;
 }
+
+export type PlaceMarketOrderWithTargetValueParams = Omit<PlaceOrderSpotParams, 'type'>;
+
+export type PlaceMarketOrderWithTargetValueWithPermitParams = Omit<PlaceOrderWithPermitSpotParams, 'type'>;
 
 export type BatchPlaceOrderSpotParams = {
   market: string;


### PR DESCRIPTION
1. Methods to place market orders by setting quote token, supports permit, and native token.
2. Split contract methods tests.