### PR TITLE
Fix: Market data cache

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -31,7 +31,7 @@
       }
     },
     "..": {
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.1.2",

--- a/src/services/hanjiSpotWebSocketService/dtos.ts
+++ b/src/services/hanjiSpotWebSocketService/dtos.ts
@@ -71,6 +71,9 @@ export interface FillUpdateDto {
 }
 
 export interface CandleUpdateDto {
+  market: {
+    id: string;
+  };
   resolution: string;
   time: number;
   open: string;
@@ -82,6 +85,9 @@ export interface CandleUpdateDto {
 }
 
 export interface TradeUpdateDto {
+  market: {
+    id: string;
+  };
   tradeId: string;
   direction: Direction;
   price: string;


### PR DESCRIPTION
[CLOB-131](https://longgammalabs.atlassian.net/browse/CLOB-131)

1. **Updated `getMarket()` method**. Modified the `getMarket` method to fetch market data directly via API requests, bypassing previously used cached data. This ensures up-to-date market information is retrieved with each call

2. **New `getCachedMarkets()` method**. Added the `getCachedMarkets` method, which returns market data from cache if available. If no cached data exists, it triggers an API request to fetch all markets data

3. Replaced calls from `getMarkets` to `getCachedMarkets` within mapping functions