### PR TITLE
Fix: api response types for fees

### DIFF
--- a/src/services/hanjiSpotService/dtos.ts
+++ b/src/services/hanjiSpotService/dtos.ts
@@ -115,9 +115,9 @@ export interface MarketDto {
   lastTouched: number;
   supportsNativeToken: boolean;
   isNativeTokenX: boolean;
-  aggressiveFee: number;
-  passiveFee: number;
-  passiveOrderPayout: number;
+  aggressiveFee: string;
+  passiveFee: string;
+  passiveOrderPayout: string;
 }
 
 export interface CandleDto {

--- a/src/services/hanjiSpotWebSocketService/dtos.ts
+++ b/src/services/hanjiSpotWebSocketService/dtos.ts
@@ -119,9 +119,9 @@ export interface MarketUpdateDto {
   quoteToken: TokenUpdateDto;
   supportsNativeToken: boolean;
   isNativeTokenX: boolean;
-  aggressiveFee: number;
-  passiveFee: number;
-  passiveOrderPayout: number;
+  aggressiveFee: string;
+  passiveFee: string;
+  passiveOrderPayout: string;
 }
 
 export interface TokenUpdateDto {

--- a/src/spot/mappers.ts
+++ b/src/spot/mappers.ts
@@ -54,9 +54,9 @@ export const mapMarketDtoToMarket = (dto: MarketDto, priceFactor: number, sizeFa
     tradingVolume24h: dto.tradingVolume24h ? tokenUtils.convertTokensRawAmountToAmount(dto.tradingVolume24h, sizeFactor) : null,
     totalSupply: dto.totalSupply ? BigNumber(dto.totalSupply) : null,
     lastTouched: dto.lastTouched,
-    aggressiveFee: dto.aggressiveFee,
-    passiveFee: dto.passiveFee,
-    passiveOrderPayout: dto.passiveOrderPayout,
+    aggressiveFee: Number(dto.aggressiveFee),
+    passiveFee: Number(dto.passiveFee),
+    passiveOrderPayout: Number(dto.passiveOrderPayout),
   };
 };
 


### PR DESCRIPTION
Api returns fees in strings, converting it to numbers in mappers